### PR TITLE
Better validation

### DIFF
--- a/bin/exman
+++ b/bin/exman
@@ -5,85 +5,89 @@ import sys
 import shutil
 import exman
 import os
-parser = argparse.ArgumentParser()
-commands = parser.add_subparsers(title='commands', help='Experiment manager CLI')
 
-mark = commands.add_parser('mark')
+parser = argparse.ArgumentParser()
+commands = parser.add_subparsers(title="commands", help="Experiment manager CLI")
+
+mark = commands.add_parser("mark")
 
 
 def key_validator(key):
     try:
         path = pathlib.Path(key)
     except (TypeError, NotImplementedError):
-        raise argparse.ArgumentError('Mark "{}" should be a valid relative path'.format(key))
+        raise argparse.ArgumentError(
+            'Mark "{}" should be a valid relative path'.format(key)
+        )
     else:
         if path.is_absolute():
-            raise argparse.ArgumentError('Mark "{}" should be a valid relative path'.format(key))
+            raise argparse.ArgumentError(
+                'Mark "{}" should be a valid relative path'.format(key)
+            )
     return path
 
 
-mark.add_argument('key',
-                  type=key_validator,
-                  help='key for mark')
+mark.add_argument("key", type=key_validator, help="key for mark")
 
 
 class Mark(argparse.Action):
-    def __init__(self, option_strings, dest=argparse.SUPPRESS, nargs='+', **kwargs):
+    def __init__(self, option_strings, dest=argparse.SUPPRESS, nargs="+", **kwargs):
         super().__init__(option_strings, dest=dest, nargs=nargs, type=int, **kwargs)
 
     def __call__(self, parser, namespace, values, option_string=None):
         selected = set(values)
-        dest = pathlib.Path('marked') / namespace.key
-        for run in pathlib.Path('runs').iterdir():
-            ind = int(run.name.split('-', 1)[0])
+        dest = pathlib.Path("marked") / namespace.key
+        for run in pathlib.Path("runs").iterdir():
+            ind = int(run.name.split("-", 1)[0])
             if ind in selected:
                 os.makedirs(dest, exist_ok=True)
-                rel_param_symlink = pathlib.Path('..', *(['..'] * len(namespace.key.parts))) / 'runs' / run.name
+                rel_param_symlink = (
+                    pathlib.Path("..", *([".."] * len(namespace.key.parts)))
+                    / "runs"
+                    / run.name
+                )
                 (dest / run.name).symlink_to(
-                    rel_param_symlink,
-                    target_is_directory=True
+                    rel_param_symlink, target_is_directory=True
                 )
                 selected.remove(ind)
-                print('Created symlink from', dest / run.name, '->', rel_param_symlink)
+                print("Created symlink from", dest / run.name, "->", rel_param_symlink)
         if selected:
-            sys.stderr.write('warning: runs {} were not found\n'.format(selected))
+            sys.stderr.write("warning: runs {} were not found\n".format(selected))
         parser.exit(0)
 
 
-mark.add_argument('runs',
-                  help='runs to mark',
-                  action=Mark)
+mark.add_argument("runs", help="runs to mark", action=Mark)
 
-delete = commands.add_parser('delete')
-delete.add_argument('--all', action='store_true', help='Delete all associated files too')
+delete = commands.add_parser("delete")
+delete.add_argument(
+    "--all", action="store_true", help="Delete all associated files too"
+)
 
 
 class Delete(argparse.Action):
-    def __init__(self, option_strings, dest=argparse.SUPPRESS, nargs='+', **kwargs):
+    def __init__(self, option_strings, dest=argparse.SUPPRESS, nargs="+", **kwargs):
         super().__init__(option_strings, dest=dest, nargs=nargs, type=int, **kwargs)
 
     def __call__(self, parser, namespace, values, option_string=None):
         selected = set(values)
-        for index in pathlib.Path('index').iterdir():
-            ind = int(index.name.split('-', 1)[0])
+        for index in pathlib.Path("index").iterdir():
+            ind = int(index.name.split("-", 1)[0])
             if ind in selected:
                 index.unlink()
                 if not namespace.all:
                     selected.remove(ind)
         if namespace.all:
-            for run in pathlib.Path('runs').iterdir():
-                ind = int(run.name.split('-', 1)[0])
+            for run in pathlib.Path("runs").iterdir():
+                ind = int(run.name.split("-", 1)[0])
                 if ind in selected:
                     shutil.rmtree(run, ignore_errors=True)
                     selected.remove(ind)
         if selected:
-            sys.stderr.write('warning: runs {} were not found\n'.format(selected))
+            sys.stderr.write("warning: runs {} were not found\n".format(selected))
         parser.exit(0)
 
 
-delete.add_argument('runs',
-                    action=Delete,
-                    help='runs to delete')
-if __name__ == '__main__':
-    exman.parser.ExmanDirectory('.', mode='validate')
+delete.add_argument("runs", action=Delete, help="runs to delete")
+if __name__ == "__main__":
+    exman.parser.ExmanDirectory(".", mode="validate")
     parser.parse_args()

--- a/exman/__init__.py
+++ b/exman/__init__.py
@@ -1,4 +1,4 @@
-from .parser import ExParser, simpleroot, optional
+from .parser import ExParser, simpleroot, optional, ArgumentError
 from .index import Index
 from . import index
 from . import parser

--- a/exman/__init__.py
+++ b/exman/__init__.py
@@ -3,4 +3,4 @@ from .index import Index
 from . import index
 from . import parser
 
-__version__ = "0.1.2"
+__version__ = "0.1.3"

--- a/exman/parser.py
+++ b/exman/parser.py
@@ -12,7 +12,7 @@ import shutil
 import traceback
 from filelock import FileLock
 
-__all__ = ["ExParser", "simpleroot", "optional"]
+__all__ = ["ExParser", "simpleroot", "optional", "ArgumentError"]
 
 
 TIME_FORMAT_DIR = "%Y-%m-%d-%H-%M-%S"
@@ -23,6 +23,8 @@ PARAMS_FILE = "params." + EXT
 FOLDER_DEFAULT = "exman"
 
 Validator = collections.namedtuple("Validator", "call,message")
+# make this public
+ArgumentError = argparse.ArgumentError
 
 
 def yaml_file(name):
@@ -318,6 +320,9 @@ class ExParser(ParserWithRoot):
 def _validate(validator: Validator, params: argparse.Namespace):
     try:
         ret = validator.call(params)
+    except argparse.ArgumentError as e:
+        # do not override this error
+        raise e
     except Exception as e:
         raise argparse.ArgumentError(
             None, validator.message.format(**params.__dict__)


### PR DESCRIPTION
This adds a smarter way to validate params:

This api assumes `exman.ArgumentError` can be raised inside the validation function and thus already contains meaningful error message that should not be overriden